### PR TITLE
#2879 : Memory Leak : LOG4J Hierarchy keeps a Hashtable of all dynami…

### DIFF
--- a/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogs.java
+++ b/scheduler/scheduler-api/src/main/java/org/ow2/proactive/scheduler/common/task/Log4JTaskLogs.java
@@ -57,7 +57,7 @@ public class Log4JTaskLogs implements TaskLogs {
     private static final long serialVersionUID = 1L;
 
     /** Prefix for job logger */
-    public static final String JOB_LOGGER_PREFIX = "schedulerloggers";
+    public static final String JOB_LOGGER_PREFIX = "logger.scheduler.";
 
     public static final String MDC_JOB_ID = "job.id";
 

--- a/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLogger.java
+++ b/scheduler/scheduler-node/src/main/java/org/ow2/proactive/scheduler/task/TaskLogger.java
@@ -93,7 +93,8 @@ public class TaskLogger {
     private Logger createLog4jLogger(TaskId taskId) {
         LogLog.setQuietMode(true); // error about log should not be logged
 
-        Logger tempLogger = Logger.getLogger(Log4JTaskLogs.JOB_LOGGER_PREFIX + taskId.toString());
+        Logger tempLogger = Logger.getLogger(Log4JTaskLogs.JOB_LOGGER_PREFIX + taskId.getJobId() + "." +
+                                             taskId.value());
         tempLogger.setLevel(Log4JTaskLogs.STDOUT_LEVEL);
         tempLogger.setAdditivity(false);
 

--- a/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
+++ b/scheduler/scheduler-node/src/test/java/org/ow2/proactive/scheduler/task/TaskLoggerTest.java
@@ -46,6 +46,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
 import org.ow2.proactive.scheduler.common.job.JobId;
+import org.ow2.proactive.scheduler.common.task.Log4JTaskLogs;
 import org.ow2.proactive.scheduler.common.task.TaskId;
 import org.ow2.proactive.scheduler.common.util.TaskLoggerRelativePathGenerator;
 import org.ow2.proactive.scheduler.common.util.logforwarder.AppenderProvider;
@@ -185,5 +186,6 @@ public class TaskLoggerTest {
             loggers.get(i).close();
             assertNull(LogManager.exists(loggers.get(i).getName()));
         }
+        assertNull(LogManager.exists(Log4JTaskLogs.getLoggerName("" + 1000)));
     }
 }

--- a/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
+++ b/scheduler/scheduler-server/src/main/java/org/ow2/proactive/scheduler/core/db/SchedulerDBManager.java
@@ -864,7 +864,7 @@ public class SchedulerDBManager {
                     ids.add(jobId(jobId));
                 }
 
-                List<InternalJob> result = new ArrayList<>();
+                List<InternalJob> result = new ArrayList<>(jobIds.length);
                 batchLoadJobs(session, false, jobQuery, ids, result);
                 return result;
             }


### PR DESCRIPTION
…c job and task loggers without any cleaning strategy

- Preserve the logger categories as without that the job logging mechanism does not work
- Remove the logger in the hashtable and inside its parents vectors